### PR TITLE
UltiSnips_Anon is deprecated, using UltiSnips#Anon instead

### DIFF
--- a/autoload/pdv.vim
+++ b/autoload/pdv.vim
@@ -110,7 +110,7 @@ func! pdv#DocumentWithSnip()
 	call append(l:docline - 1, [""])
 	call cursor(l:docline, 0)
 
-    call UltiSnips_Anon(l:snippet)
+    call UltiSnips#Anon(l:snippet)
 endfunc
 
 func! s:DetermineParseConfig(line)


### PR DESCRIPTION
UltiSnips_Anon is deprecated, using UltiSnips#Anon instead in pdv#DocumentWithSnip function
