### PR TITLE
correct link format from MarkDown to RST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,9 @@ Try it out now.
 ------------
 Requirements
 ------------
-[Vmustache](https://github.com/tobyS/vmustache) is a required plugin for PDV to work
+Vmustache__ is a required plugin for PDV to work
+
+__ https://github.com/tobyS/vmustache 
 
 
 -------


### PR DESCRIPTION
Requirements link in readme was down with MarkDown
rather than RST. fixes this.

This corrects an error in my PR #6
