### PR TITLE
Improve type-guessing from default values

### DIFF
--- a/autoload/pdv.vim
+++ b/autoload/pdv.vim
@@ -61,11 +61,11 @@ let s:regex["class"] = '^\(\s*\)\(\S*\)\s*\(interface\|class\)\s*\(\S\+\)\s*\([^
 
 let s:regex["types"] = {}
 
-let s:regex["types"]["array"]  = "^array *(.*"
+let s:regex["types"]["array"]  = '^array *(.*\c'
 let s:regex["types"]["float"]  = '^[0-9]*\.[0-9]\+'
 let s:regex["types"]["int"]    = '^[0-9]\+'
 let s:regex["types"]["string"] = "['\"].*"
-let s:regex["types"]["bool"] = '\(true\|false\)'
+let s:regex["types"]["bool"] = '\(true\|false\)\c'
 
 let s:regex["indent"] = '^\s*'
 


### PR DESCRIPTION
Fix broken regex for type-guessing bools, and make type-guessing of bools and arrays case insensitive.
