### PR TITLE
Add the return type to function comments

### DIFF
--- a/autoload/pdv.vim
+++ b/autoload/pdv.vim
@@ -75,6 +75,9 @@ let s:regex["interface"] = '^\(\s*\)interface\s\+\(\S\+\)\(\s\+extends\s\+\(\S\+
 " 1:indent, 2:name
 let s:regex["trait"] = '^\(\s*\)trait\s\+\(\S\+\)\s*{\?\s*$'
 
+let s:regex["variable"] = '^\(\s*\)\(\$[^ =]\+\)\s*=\s*\([^;]\+\);$'
+let s:regex["newobject"] = '^\s*new\s*\([^(;]\+\).*$'
+
 let s:regex["types"] = {}
 
 let s:regex["types"]["array"]  = "^array *(.*"
@@ -104,6 +107,9 @@ let s:mapping = [
     \ {"regex": s:regex["trait"],
     \  "function": function("pdv#ParseTraitData"),
     \  "template": "trait"},
+    \ {"regex": s:regex["variable"],
+    \  "function": function("pdv#ParseVariableData"),
+    \  "template": "variable"},
 \ ]
 
 func! pdv#DocumentCurrentLine()
@@ -225,6 +231,28 @@ func! pdv#ParseTraitData(line)
 	return l:data
 endfunc
 
+func! pdv#ParseVariableData(line)
+	let l:text = getline(a:line)
+
+	let l:data = {}
+	let l:matches = matchlist(l:text, s:regex["variable"])
+
+	let l:data["indent"] = l:matches[1]
+	let l:data["name"] = l:matches[2]
+	" TODO: Cleanup ; and friends
+	let l:data["default"] = get(l:matches, 3, '')
+
+	let l:types = matchlist(l:matches[3], s:regex["newobject"])
+	if (!empty(l:types))
+		let l:data["type"] = l:types[1]
+	elseif (!empty(l:data["default"]))
+		let l:data["type"] = s:GuessType(l:data["default"])
+	endif
+
+	return l:data
+endfunc
+
+
 func! s:ParseExtendsImplements(data, text)
 	let l:tokens = split(a:text, '\(\s*,\s*\|\s\+\)')
 
@@ -301,7 +329,7 @@ func! pdv#ParseFunctionData(line)
 	for l:param in l:parameters
 		call add(l:data["parameters"], s:ParseParameterData(l:param))
 	endfor
-	
+
 	if (l:functionData["return"] != "")
 		let l:data["return"] = l:functionData["return"]
 	endif

--- a/autoload/pdv.vim
+++ b/autoload/pdv.vim
@@ -295,11 +295,16 @@ func! pdv#ParseFunctionData(line)
 	let l:data = s:ParseBasicFunctionData(l:text)
 	let l:data["parameters"] = []
 
-	let l:parameters = parparse#ParseParameters(a:line)
+	let l:functionData = parparse#ParseParameters(a:line)
+	let l:parameters = l:functionData["parameters"]
 
 	for l:param in l:parameters
 		call add(l:data["parameters"], s:ParseParameterData(l:param))
 	endfor
+	
+	if (l:functionData["return"] != "")
+		let l:data["return"] = l:functionData["return"]
+	endif
 
 	return l:data
 endfunc

--- a/templates/function.tpl
+++ b/templates/function.tpl
@@ -2,4 +2,5 @@
  * {{name}}
  *{{#parameters}}
  * @param {{type}}{{^type}}mixed{{/type}} ${{name}}{{/parameters}}
- */
+ {{#return}}* @return {{return}} 
+ {{/return}}*/

--- a/templates/variable.tpl
+++ b/templates/variable.tpl
@@ -1,0 +1,1 @@
+/** @var {{type}}{{^type}}mixed{{/type}} {{name}} */

--- a/templates_snip/function.tpl
+++ b/templates_snip/function.tpl
@@ -2,4 +2,5 @@
  * ${1:{{name}}}{{?func: vmustache#InitCounter("params", 1)}}
  *{{#parameters}}
  * @param ${{{?func: vmustache#IncrementCounter("params")}}:{{type}}{{^type}}mixed{{/type}}} ${{name}}${{{?func: vmustache#IncrementCounter("params")}}}{{/parameters}}
- */
+ {{#return}}* @return {{return}} 
+ {{/return}}*/

--- a/templates_snip/variable.tpl
+++ b/templates_snip/variable.tpl
@@ -1,0 +1,1 @@
+/** @var ${2:{{type}}{{^type}}mixed{{/type}}} ${1:{{name}}} */


### PR DESCRIPTION
Hello @tobyS 
As you said in https://github.com/tobyS/pdv/issues/10 I created a pull request for return types.

It works fine for this functions like this:
![image](https://user-images.githubusercontent.com/9335727/31887827-6c645996-b802-11e7-9d72-ad04733ba0f7.png)
![image](https://user-images.githubusercontent.com/9335727/31887837-7d743f30-b802-11e7-9725-98569fd943cd.png)
![image](https://user-images.githubusercontent.com/9335727/31887859-936bde9c-b802-11e7-9303-6ffa3f03efd6.png)

